### PR TITLE
Redisのセッションストアとヘルスチェックを1つのアダプタにしたのでbomを変更

### DIFF
--- a/nablarch-bom/pom.xml
+++ b/nablarch-bom/pom.xml
@@ -467,7 +467,7 @@
 
       <dependency>
         <groupId>com.nablarch.integration</groupId>
-        <artifactId>nablarch-redisstore-lettuce-adaptor</artifactId>
+        <artifactId>nablarch-lettuce-adaptor</artifactId>
         <version>1.0.0-SNAPSHOT</version>
       </dependency>
 


### PR DESCRIPTION
https://github.com/nablarch/nablarch-lettuce-adaptor/pull/1
上記対応をbomに反映しました。