### PR TITLE
X-Rayアダプタ追加

### DIFF
--- a/nablarch-bom/pom.xml
+++ b/nablarch-bom/pom.xml
@@ -483,6 +483,12 @@
         <version>5-NEXT-SNAPSHOT</version>
       </dependency>
 
+      <dependency>
+        <groupId>com.nablarch.integration</groupId>
+        <artifactId>nablarch-aws-xray-adaptor</artifactId>
+        <version>5-NEXT-SNAPSHOT</version>
+      </dependency>
+
       <!-- サードパーティライブラリ -->
       <dependency>
         <groupId>taglibs</groupId>


### PR DESCRIPTION
AWS X-RayアダプタはAWSから[Javaエージェントとして動作するAWS X-Rayクライアント](https://aws.amazon.com/jp/about-aws/whats-new/2020/09/aws-x-ray-launches-auto-instrumentation-agent-for-java/)がリリースされたためにNablarch5u18でのリリースを見送っていた。
しかし、Javaエージェントの動作を検証したところ、Nablarchでは利用できなかったため、5u19にてリリースすることになった。
