### PR TITLE
nablarch-workflowをbomに記載

### DIFF
--- a/nablarch-bom/pom.xml
+++ b/nablarch-bom/pom.xml
@@ -164,6 +164,12 @@
         <version>5-NEXT-SNAPSHOT</version>
       </dependency>
 
+      <dependency>
+        <groupId>com.nablarch.workflow</groupId>
+        <artifactId>nablarch-workflow</artifactId>
+        <version>5-NEXT-SNAPSHOT</version>
+      </dependency>
+
       <!-- fw -->
       <dependency>
         <groupId>com.nablarch.framework</groupId>


### PR DESCRIPTION
## 背景

exampleのpom.xmlに、モジュールのバージョンを固定で記載しているものが無いかを確認した。  
その際、nablarch-workflowがbomに記載可能であるにも関わらず記載されていないことが分かった。

## 対応内容
nablarch-workflow をbomに記載した。

## 確認内容
- nablarch-example-workflowでの動作確認。