### PR TITLE
X-Rayアダプタ削除

### DIFF
--- a/nablarch-bom/pom.xml
+++ b/nablarch-bom/pom.xml
@@ -489,12 +489,6 @@
         <version>5-NEXT-SNAPSHOT</version>
       </dependency>
 
-      <dependency>
-        <groupId>com.nablarch.integration</groupId>
-        <artifactId>nablarch-aws-xray-adaptor</artifactId>
-        <version>5-NEXT-SNAPSHOT</version>
-      </dependency>
-
       <!-- サードパーティライブラリ -->
       <dependency>
         <groupId>taglibs</groupId>


### PR DESCRIPTION
5u19でX-Rayアダプタをリリースしようとしたが、[AWS Distro for OpenTelemetry](https://docs.aws.amazon.com/ja_jp/xray/latest/devguide/xray-open-telemetry.html)を使用すればJavaエージェントで分散トレーシングを実現できる可能性があることがわかった。
アダプタをリリースしたあとにJavaエージェントに方針転換すると利用者を混乱させるため、5u19ではアダプタではなくSDKを使用した分散トレーシングの方法をガイドし、アダプタのリリースは見送ることとした。