### PR TITLE
scoped-dicontainerのバージョンを最新化

### DIFF
--- a/nablarch-bom/pom.xml
+++ b/nablarch-bom/pom.xml
@@ -350,7 +350,7 @@
       <dependency>
         <groupId>com.nablarch.framework</groupId>
         <artifactId>nablarch-fw-scoped-dicontainer</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
       </dependency>
 
       <!-- Nablarch Testing Framework -->


### PR DESCRIPTION
nablarch-fw-scoped-dicontainer のバージョンが更新されていなかったので、その対応。