### PR TITLE
chore: サードパーティライブラリをbomから削除

### DIFF
--- a/nablarch-bom/pom.xml
+++ b/nablarch-bom/pom.xml
@@ -48,9 +48,6 @@
   </scm>
 
   <properties>
-    <version.geronimo-jpa_spec>1.1</version.geronimo-jpa_spec>
-    <version.taglibs.standard>1.1.2</version.taglibs.standard>
-
     <release.allow.snapshot>false</release.allow.snapshot>
     <version.nablarch.jars>${project.version}</version.nablarch.jars>
 
@@ -455,18 +452,6 @@
         <groupId>com.nablarch.integration</groupId>
         <artifactId>slf4j-nablarch-adaptor</artifactId>
         <version>6-NEXT-SNAPSHOT</version>
-      </dependency>
-
-      <!-- サードパーティライブラリ -->
-      <dependency>
-        <groupId>taglibs</groupId>
-        <artifactId>standard</artifactId>
-        <version>${version.taglibs.standard}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.geronimo.specs</groupId>
-        <artifactId>geronimo-jpa_2.0_spec</artifactId>
-        <version>${version.geronimo-jpa_spec}</version>
       </dependency>
 
       <!-- Nablarch Profiles -->


### PR DESCRIPTION
- 中途半端にサードパーティライブラリがbom管理されているので、 Jakarta EE 9 対応で変更が必要になるこのタイミングで一旦削除する
  - bom で管理するなら、 Servlet や Bean Validation など、その他のライブラリも一括で bom に持ってくる対応を別途設けるべき
- bom から削除することでこの定義を利用しているモジュールはビルドができなくなるが、 Jakarta EE 9 対応するときに手を入れるので、そのときに修正する