### PR TITLE
OSSRHからCentral Publisher Portalへ移行（v5）

### DIFF
--- a/nablarch-bom/pom.xml
+++ b/nablarch-bom/pom.xml
@@ -83,6 +83,15 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+        </configuration>
+      </plugin>
     </plugins>
     <extensions>
       <extension>
@@ -532,17 +541,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
-  <distributionManagement>
-    <repository>
-      <id>nablarch.staging</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-    </repository>
-    <snapshotRepository>
-      <id>nablarch.snapshot</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
 
   <profiles>
     <profile>

--- a/nablarch-profile-parent/pom.xml
+++ b/nablarch-profile-parent/pom.xml
@@ -92,6 +92,15 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+        </configuration>
+      </plugin>
     </plugins>
     <extensions>
       <extension>
@@ -101,17 +110,6 @@
       </extension>
     </extensions>
   </build>
-
-  <distributionManagement>
-    <repository>
-      <id>nablarch.staging</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-    </repository>
-    <snapshotRepository>
-      <id>nablarch.snapshot</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
 
   <profiles>
     <profile>


### PR DESCRIPTION
OSSRHのサービス終了に向けて、Maven Centralへのデプロイ方法をCentral Publisher Portalへ移行する。

主な変更点は以下のとおり。

- `distributionManagement`の削除
  - デプロイ先のidは`ossrh`から`central`となるが、`central`については明示的な定義は不要
  - SNAPSHOTリポジトリは使用していないので削除
- Central Publishing Mavenプラグインを追加
  - `mvn deploy`コマンドでCentral Publisher Portalにデプロイするプラグイン

一時的に`version`を5u27に変更し、nablarch-bomおよびnablarch-profile-parentのみCentral Publisher Potalへデプロイできることを確認。  
※その他のモジュールはnablarch-profile-parentを参照するため単体ではデプロイ不可

```shell
$ mvn clean deploy -DskipTests -P central
```

![image](https://github.com/user-attachments/assets/d8ebb415-6240-4938-b478-c7574c022fe2)

![image](https://github.com/user-attachments/assets/0c3222b6-fe15-4ca3-b526-1ae3da02e3b0)
